### PR TITLE
PRD Release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
 
     environment:
       name: npm-release # Links to the environment configured in GitHub Settings and on npmjs.com
-      url: https://www.npmjs.com/package/i36n
+      url: https://www.npmjs.com/package/@jota-one/i36n
 
     steps:
       - name: 'Checkout Repository'
@@ -86,7 +86,14 @@ jobs:
           BUMP=${{ steps.version_bump.outputs.BUMP_TYPE }}
           echo "Version bump type determined to be: $BUMP"
 
-          # pnpm's version command is similar to npm's
+          # Fetch the latest published version from npm, fall back to 0.0.0 if not found
+          PUBLISHED=$(npm view @jota-one/i36n version 2>/dev/null || echo "0.0.0")
+          echo "Latest published version: $PUBLISHED"
+
+          # Sync package.json to the published version before bumping
+          npm version "$PUBLISHED" --no-git-tag-version --allow-same-version
+
+          # Bump to the new version
           pnpm version $BUMP --no-git-tag
 
           echo "Publishing to npm..."

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 Translation manager twice simpler and twice better
 
 ## Installation
-### As [npm](https://www.npmjs.com/package/i36n) dependency in your node project
+### As [npm](https://www.npmjs.com/package/@jota-one/i36n) dependency in your node project
 
 Simply install it as a dependency of the project you want to internationalize.
 ```shell
-npm install i36n
+npm install @jota-one/i36n
 ```
 
 ## Usage
@@ -19,7 +19,7 @@ Then you can inject it wherever you need it.
 Somewhere before you need your first label, you have to provide the library to your app.
 In your `<script>` tag first import the library:
 ```js
-import { provideI36n } from 'i36n'
+import { provideI36n } from '@jota-one/i36n'
 ```
 
 In your `setup()` function, call the `provideI36n()` function. You need to pass it 2 parameters:
@@ -28,7 +28,7 @@ In your `setup()` function, call the `provideI36n()` function. You need to pass 
 
 ```html
 <script>
-import { provideI36n } from 'i36n'
+import { provideI36n } from '@jota-one/i36n'
 // ... imports, etc..
 
 const load = async lang => (await import(`@/i18n/${lang}.json`)).default
@@ -52,7 +52,7 @@ Once the providing is done, you can inject the library features anywhere in your
 
 In your `<script>` tag, near the top, import the library
 ```js
-import { useI36n } from 'i36n'
+import { useI36n } from '@jota-one/i36n'
 ```
 
 In your `setup()` function, call the `useI36n()` function. It will give you the `t()` translation function.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "i36n",
+  "name": "@jota-one/i36n",
   "version": "0.0.0-local",
   "type": "module",
   "description": "Translation manager twice simpler and twice better",


### PR DESCRIPTION
## Summary

- Reverted package name to `@jota-one/i36n` — npm rejected `i36n` (unscoped) as too similar to `i18n`
- Fixed release workflow target branch (`master` → `main`)
- Improved release process: CI now fetches the latest published version from npm before bumping, so `0.0.0-local` in `package.json` is a permanent placeholder never published